### PR TITLE
[Controller] Any kind of exception are now re-thrown as SoapFault. (fixes #70)

### DIFF
--- a/Controller/SoapWebServiceController.php
+++ b/Controller/SoapWebServiceController.php
@@ -126,7 +126,7 @@ class SoapWebServiceController extends ContainerAware
             } catch (\Exception $e) {
                 $this->soapResponse = new Response(null, 500);
 
-                if ($this->container->getParameter('kernel.debug')) {
+                if ($e instanceof \SoapFault || $this->container->getParameter('kernel.debug')) {
                     throw $e;
                 }
 


### PR DESCRIPTION
This is an attempt to fix #70.

I don't know it is the right way to do this but this seems to work: any kind of exception is now re-thrown as a SoapFault except when the kernel.debug parameter equals true for debugging purposes.
