### PR TITLE
Fixed processing of cyclic types that points to each other

### DIFF
--- a/ServiceDefinition/Loader/AnnotationClassLoader.php
+++ b/ServiceDefinition/Loader/AnnotationClassLoader.php
@@ -154,11 +154,11 @@ class AnnotationClassLoader extends Loader
 
             $loaded = $complexTypeResolver->load($phpType);
             $complexType = new ComplexType($phpType, isset($loaded['alias']) ? $loaded['alias'] : $phpType);
+            $this->typeRepository->addComplexType($complexType);
+
             foreach ($loaded['properties'] as $name => $property) {
                 $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable());
             }
-
-            $this->typeRepository->addComplexType($complexType);
         }
 
         return $phpType;


### PR DESCRIPTION
In the class BeSimple\SoapBundle\ServiceDefinition\Loader\AnnotationClassLoader in method loadType we have recursive call

``` php
foreach ($loaded['properties'] as $name => $property) {
    $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable());
}
```

But saving of the processed complex type is done after recursive call.

``` php
$this->typeRepository->addComplexType($complexType);
```

If in the annotations we have cyclic references then we have infinite loop while check

``` php
if (!$this->typeRepository->hasType($phpType)) {
```

is not work. When we moving line 

``` php
$this->typeRepository->addComplexType($complexType);
```

before recursive call - it works correctly.
