### PR TITLE
List of objects

### DIFF
--- a/ServiceBinding/RpcLiteralResponseMessageBinder.php
+++ b/ServiceBinding/RpcLiteralResponseMessageBinder.php
@@ -68,7 +68,14 @@ class RpcLiteralResponseMessageBinder implements MessageBinderInterface
 
                 $message = $array;
             } else {
-                $message = $this->checkComplexType($phpType, $message);
+                if (is_array($message)) {
+                    foreach ($message as $complexType) {
+                        $array[] = $this->checkComplexType($phpType, $complexType);
+                    }
+                    $message = $array;
+                } else {
+                    $message = $this->checkComplexType($phpType, $message);
+                }
             }
         }
 

--- a/ServiceDefinition/Annotation/ComplexType.php
+++ b/ServiceDefinition/Annotation/ComplexType.php
@@ -18,6 +18,8 @@ class ComplexType extends Configuration
     private $name;
     private $value;
     private $isNillable = false;
+    private $minOccurs;
+    private $maxOccurs;
 
     public function getName()
     {
@@ -47,6 +49,23 @@ class ComplexType extends Configuration
     public function setNillable($isNillable)
     {
         $this->isNillable = (bool) $isNillable;
+    }
+
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 
     public function getAliasName()

--- a/ServiceDefinition/ComplexType.php
+++ b/ServiceDefinition/ComplexType.php
@@ -20,6 +20,8 @@ class ComplexType
     private $name;
     private $value;
     private $isNillable = false;
+    private $minOccurs;
+    private $maxOccurs;
 
     public function getName()
     {
@@ -49,5 +51,25 @@ class ComplexType
     public function setNillable($isNillable)
     {
         $this->isNillable = (bool) $isNillable;
+    }
+
+    public function getMinOccurs()
+    {
+        return $this->minOccurs;
+    }
+
+    public function setMinOccurs($minOccurs)
+    {
+        $this->minOccurs = $minOccurs;
+    }
+
+    public function getMaxOccurs()
+    {
+        return $this->maxOccurs;
+    }
+
+    public function setMaxOccurs($maxOccurs)
+    {
+        $this->maxOccurs = $maxOccurs;
     }
 }

--- a/ServiceDefinition/Loader/AnnotationClassLoader.php
+++ b/ServiceDefinition/Loader/AnnotationClassLoader.php
@@ -155,7 +155,7 @@ class AnnotationClassLoader extends Loader
             $loaded = $complexTypeResolver->load($phpType);
             $complexType = new ComplexType($phpType, isset($loaded['alias']) ? $loaded['alias'] : $phpType);
             foreach ($loaded['properties'] as $name => $property) {
-                $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable());
+                $complexType->add($name, $this->loadType($property->getValue()), $property->isNillable(), $property->getMinOccurs(), $property->getMaxOccurs());
             }
 
             $this->typeRepository->addComplexType($complexType);

--- a/ServiceDefinition/Loader/AnnotationComplexTypeLoader.php
+++ b/ServiceDefinition/Loader/AnnotationComplexTypeLoader.php
@@ -58,6 +58,8 @@ class AnnotationComplexTypeLoader extends AnnotationClassLoader
                 $propertyComplexType = new ComplexType();
                 $propertyComplexType->setValue($complexType->getValue());
                 $propertyComplexType->setNillable($complexType->isNillable());
+                $propertyComplexType->setMinOccurs($complexType->getMinOccurs());
+                $propertyComplexType->setMaxOccurs($complexType->getMaxOccurs());
                 $propertyComplexType->setName($property->getName());
                 $annotations['properties']->add($propertyComplexType);
             }


### PR DESCRIPTION
This PR needs to be merged at same time than the following:
https://github.com/BeSimple/BeSimpleSoapCommon/pull/2
https://github.com/BeSimple/BeSimpleSoapWsdl/pull/1

The goal of this PR is to fix the problem described here :
https://github.com/BeSimple/BeSimpleSoap/issues/48

With this PR it's possible to define a collection of object like this:
```php
/**
 * @Soap\Alias("ParticipantTypeDetail")
 */
class ParticipantTypeDetail
{
    /**
     * @var string
     * @Soap\ComplexType("string")
     */
    private $name;

    /**
     * @var ParticipantTypeProperty[]
     * @Soap\ComplexType("PTC\WsBundle\TO\ParticipantProperty", minOccurs="1", maxOccurs="unbounded")
     */
    private $participantList;
```

The related generated WSDL is:
```
<xsd:complexType name="ParticipantTypeDetail">
    <xsd:all>
        <xsd:element name="name" type="xsd:string"/>
        <xsd:element name="participantList" type="tns:ParticipantProperty" minOccurs="1" maxOccurs="unbounded"/>
    </xsd:all>
</xsd:complexType>
```

Sample of response from a WS Call:
```
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://organisation.novento-reloaded.eu/ws/MobileApi/1.0/">
   <SOAP-ENV:Body>
      <ns1:getParticipantTypeDetailsResponse>
         <return>
            <name>Supplier</name>
            <participantList>
               <id>12</id>
               <firstName>Thomas</firstName>
               <lastName>Lallement</lastName>
               <organisation>Decostanding</organisation>
               <position>Driver</position>
               <participationStatusClass>accredited</participationStatusClass>
            </participantList>
            <participantList>
               <id>22</id>
               <firstName>Jerome</firstName>
               <lastName>Martin</lastName>
               <organisation>Decostanding</organisation>
               <position>Fire departement</position>
               <participationStatusClass>requested</participationStatusClass>
            </participantList>
         </return>
      </ns1:getParticipantTypeDetailsResponse>
   </SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```

So from the client side we can fetch the results by doing (sample with PHP Classmap)
```php
$participantList = $myObject->getParticipantList();
```

Rather than (current behavior):
```php
$participantList = $myObject->getParticipantList()->item;
```